### PR TITLE
Remove unused for label

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -212,7 +212,7 @@ where
         stream.next_in = input_buf.as_ptr();
         stream.avail_in = read_size as u32;
 
-        'inner: loop {
+        loop {
             let ret: binding::xd3_rvalues = unsafe {
                 std::mem::transmute(match mode {
                     Mode::Encode => binding::xd3_encode_input(stream),


### PR DESCRIPTION
```
    Checking oneshot_broadcast v0.1.0 (/Users/lion/code/sigp/lighthouse/common/oneshot_broadcast)
    Checking malloc_utils v0.1.0 (/Users/lion/code/sigp/lighthouse/common/malloc_utils)
   Compiling lighthouse v5.2.0 (/Users/lion/code/sigp/lighthouse/lighthouse)
    Checking eth2_wallet v0.1.0 (/Users/lion/code/sigp/lighthouse/crypto/eth2_wallet)
    Checking eth2_wallet_manager v0.1.0 (/Users/lion/code/sigp/lighthouse/common/eth2_wallet_manager)
warning: unused label
   --> /Users/lion/code/sigp/xdelta3-rs/src/stream.rs:215:9
    |
215 |         'inner: loop {
    |         ^^^^^^
    |
    = note: `#[warn(unused_labels)]` on by default

warning: `xdelta3` (lib) generated 1 warning
```